### PR TITLE
 Add option to autoformat docstrings according to PEP257 using docformatter

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,3 +16,5 @@ Joseph Martinot-Lagarde ([@Nodd](http://github.com/Nodd))
 Gonzalo Peña-Castellanos ([@goanpeca](http://github.com/goanpeca))
 
 Steven Silvester ([@blink1073](http://github.com/blink1073))
+
+David Breuer ([@blink1073](http://github.com/DavidBreuer))

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,4 +17,4 @@ Gonzalo Peña-Castellanos ([@goanpeca](http://github.com/goanpeca))
 
 Steven Silvester ([@blink1073](http://github.com/blink1073))
 
-David Breuer ([@blink1073](http://github.com/DavidBreuer))
+David Breuer ([@DavidBreuer](http://github.com/DavidBreuer))

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ Description
 -----------
 
 This is a plugin to run the `autopep8 <https://pypi.python.org/pypi/autopep8>`_ python linter from within the python IDE `spyder <https://github.com/spyder-ide/spyder>`_.
+Optionally, docstrings are autoformatted using python `docformatter <https://github.com/myint/docformatter>`_.
 
 
 Important Announcement: Spyder is unfunded!
@@ -57,6 +58,7 @@ Requirements
 
   spyder
   autopep8
+  docformatter
 
 
 Install instructions
@@ -77,6 +79,8 @@ Press Shift+F8 (default) to run autopep8 on the current file or go to ``Source >
 If some text is selected, autopep8 will run on this text only.
 
 Informations about the execution will be displayed in the statusbar.
+
+Additional formatting of docstrings can be enabled in the settings via ``Tools > Preferences > Autopep8 > docformatter``.
 
 Screenshot
 ----------

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     version=get_version(),
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     package_data={LIBNAME: get_package_data(LIBNAME, EXTLIST)},
-    keywords=["Qt PyQt4 PyQt5 PySide spyder plugins spyplugins autopep8 pep8"],
+    keywords=["Qt PyQt4 PyQt5 PySide spyder plugins spyplugins autopep8 pep8 docformatter"],
     install_requires=REQUIREMENTS,
     url='https://github.com/spyder-ide/spyder.autopep8',
     license='MIT',

--- a/spyder_autopep8/autopep8plugin.py
+++ b/spyder_autopep8/autopep8plugin.py
@@ -403,6 +403,6 @@ class AutoPEP8(SpyderPluginMixin):  # pylint: disable=R0904
         cursor.setPosition(position_start, QTextCursor.MoveAnchor)
         cursor.setPosition(position_end, QTextCursor.KeepAnchor)
         editor.setTextCursor(cursor)
-        
+
         self.main.statusBar().showMessage(
             _("Autopep8 finished!"))


### PR DESCRIPTION
This is just a small addition/option to autoformat docstrings using the docformatter package. Consequently, a new dependency (docformatter) is introduced. If this should be avoided, and the pull request is rejected, I fully understand. If there is anything else I should correct or change, please let me know. Thanks for your work and best, David